### PR TITLE
Un-deprecated XADArchive

### DIFF
--- a/XADArchive.m
+++ b/XADArchive.m
@@ -1107,13 +1107,16 @@ fileFraction:(double)fileprogress estimatedTotalFraction:(double)totalprogress
 
 	if(mod)
 	{
-		NSCalendarDate *cal=[mod dateWithCalendarFormat:nil timeZone:[NSTimeZone defaultTimeZone]];
-		fi->xfi_Date.xd_Year=[cal yearOfCommonEra];
-		fi->xfi_Date.xd_Month=[cal monthOfYear];
-		fi->xfi_Date.xd_Day=[cal dayOfMonth];
-		fi->xfi_Date.xd_Hour=[cal hourOfDay];
-		fi->xfi_Date.xd_Minute=[cal minuteOfHour];
-		fi->xfi_Date.xd_Second=[cal secondOfMinute];
+        NSUInteger dateComponents = NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear |
+                                        NSCalendarUnitHour | NSCalendarUnitMinute |NSCalendarUnitSecond;
+        NSDateComponents *components = [[NSCalendar currentCalendar] components:dateComponents
+                                                                       fromDate:mod];
+		fi->xfi_Date.xd_Year=[components year];
+		fi->xfi_Date.xd_Month=[components month];
+		fi->xfi_Date.xd_Day=[components day];
+		fi->xfi_Date.xd_Hour=[components hour];
+		fi->xfi_Date.xd_Minute=[components minute];
+		fi->xfi_Date.xd_Second=[components second];
 	}
 	else fi->xfi_Flags|=1<<6;
 

--- a/XADMaster.xcodeproj/project.pbxproj
+++ b/XADMaster.xcodeproj/project.pbxproj
@@ -1367,6 +1367,7 @@
 		1BF3BA9013EE08A300BE7400 /* XADPlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BF3BA8F13EE08A300BE7400 /* XADPlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1BF3BA9113EE08A300BE7400 /* XADPlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BF3BA8F13EE08A300BE7400 /* XADPlatform.h */; };
 		1BF3BA9213EE08A300BE7400 /* XADPlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BF3BA8F13EE08A300BE7400 /* XADPlatform.h */; };
+		2276D303264379ED0042D30D /* XADArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B5A80B50A27AA9900B189EB /* XADArchive.m */; };
 		73032E6C2626D3DD000C2751 /* XADWARCParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 73032E6B2626D3DD000C2751 /* XADWARCParserTests.m */; };
 		73032E6E2626DB7C000C2751 /* WARCFixtures in Resources */ = {isa = PBXBuildFile; fileRef = 73032E6D2626DB7C000C2751 /* WARCFixtures */; };
 		7318A41D248C67E400D327B9 /* XADRARParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7318A41C248C67E400D327B9 /* XADRARParserTests.m */; };
@@ -2272,7 +2273,6 @@
 			children = (
 				08FB77AEFE84172EC02AAC07 /* Classes */,
 				1B06D5B80DDA66AA00D9C000 /* Archive Parsers */,
-				1B5F13C514119F2D0078DF5C /* Deprecated */,
 				1BC89A7D0EDB1BA6006B47FE /* Compression Utilities */,
 				1BC886D80ECE18EF006B47FE /* Utilities */,
 				1BE97607163CC2A100BB34EA /* Crypto */,
@@ -2318,6 +2318,8 @@
 		08FB77AEFE84172EC02AAC07 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				1B5A7AF50A24CFD200B189EB /* XADArchive.h */,
+				1B5A80B50A27AA9900B189EB /* XADArchive.m */,
 				1BBAB6760EC26AA6007FE6A2 /* XADArchiveParser.h */,
 				1BBAB6770EC26AA6007FE6A2 /* XADArchiveParser.m */,
 				1BBEF8AE14D8A31700790E4B /* XADArchiveParserDescriptions.h */,
@@ -2690,15 +2692,6 @@
 				1B3A650110154DCE00AE25A8 /* CSHexDump.m */,
 			);
 			name = XADTest;
-			sourceTree = "<group>";
-		};
-		1B5F13C514119F2D0078DF5C /* Deprecated */ = {
-			isa = PBXGroup;
-			children = (
-				1B5A7AF50A24CFD200B189EB /* XADArchive.h */,
-				1B5A80B50A27AA9900B189EB /* XADArchive.m */,
-			);
-			name = Deprecated;
 			sourceTree = "<group>";
 		};
 		1B690E840F47944400A415E0 /* Wrappers */ = {
@@ -4280,6 +4273,7 @@
 				1B467A4F15CD9A73001AB1DD /* XADRARVirtualMachine.m in Sources */,
 				1B467A5015CD9A73001AB1DD /* Bra.c in Sources */,
 				1B467A5115CD9A73001AB1DD /* Bra86.c in Sources */,
+				2276D303264379ED0042D30D /* XADArchive.m in Sources */,
 				1B467A5215CD9A73001AB1DD /* Lzma2Dec.c in Sources */,
 				1B467A5315CD9A73001AB1DD /* LzmaDec.c in Sources */,
 				1B467A5415CD9A73001AB1DD /* XAD7ZipBCJ2Handle.m in Sources */,


### PR DESCRIPTION
`XADArchive` is the class that interfaces with all of the parsers and lets other code extract files on a file-by-file basis.

MacPaw had deprecated it, assumedly because since they only use this for The Unarchiver, and that app's use case is to only ever extract all files at once, so this functionality isn't needed.

`XADArchive` is my entry point in iComics, so I needed to restore this, and fix all of the deprecated build warnings.